### PR TITLE
Update OpenAI import for API key testing

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -199,7 +199,8 @@ const SettingsPage: React.FC = () => {
 
     try {
       // Test the API key by making a simple request
-      const testClient = new (await import("openai")).default({
+      const { default: OpenAI } = await import("openai");
+      const testClient = new OpenAI({
         apiKey: apiKey.trim(),
         dangerouslyAllowBrowser: true,
       });


### PR DESCRIPTION
## Summary
- refactor `testApiKey` in `SettingsPage.tsx` to properly import OpenAI

## Testing
- `npm run lint` *(fails: 76 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6856f66c77ec832fad64c6ddbf0c4a44